### PR TITLE
Add auto retry for API requests

### DIFF
--- a/NorrisFacts.xcodeproj/project.pbxproj
+++ b/NorrisFacts.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		FA1CF64924B629FC00409CB0 /* UITableView+ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1CF64824B629FC00409CB0 /* UITableView+ext.swift */; };
 		FA1CF64C24B62B3A00409CB0 /* FactTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1CF64A24B62B3A00409CB0 /* FactTableViewCell.swift */; };
 		FA1CF64D24B62B3A00409CB0 /* FactTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA1CF64B24B62B3A00409CB0 /* FactTableViewCell.xib */; };
+		FA6DB40124C38C79005D0C5E /* HttpServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6DB40024C38C79005D0C5E /* HttpServiceMock.swift */; };
+		FA6DB40324C38CBA005D0C5E /* NorrisFactServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6DB40224C38CBA005D0C5E /* NorrisFactServiceMock.swift */; };
 		FAD3201224B6472E0044C83E /* fact-short-text.json in Resources */ = {isa = PBXBuildFile; fileRef = FAD3201124B6472E0044C83E /* fact-short-text.json */; };
 		FAD3201424B647580044C83E /* fact-long-text.json in Resources */ = {isa = PBXBuildFile; fileRef = FAD3201324B647580044C83E /* fact-long-text.json */; };
 		FAD3201624B64A6C0044C83E /* FactItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD3201524B64A6C0044C83E /* FactItemViewModel.swift */; };
@@ -162,6 +164,8 @@
 		FA1CF64824B629FC00409CB0 /* UITableView+ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+ext.swift"; sourceTree = "<group>"; };
 		FA1CF64A24B62B3A00409CB0 /* FactTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactTableViewCell.swift; sourceTree = "<group>"; };
 		FA1CF64B24B62B3A00409CB0 /* FactTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FactTableViewCell.xib; sourceTree = "<group>"; };
+		FA6DB40024C38C79005D0C5E /* HttpServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpServiceMock.swift; sourceTree = "<group>"; };
+		FA6DB40224C38CBA005D0C5E /* NorrisFactServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NorrisFactServiceMock.swift; sourceTree = "<group>"; };
 		FAD3201124B6472E0044C83E /* fact-short-text.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "fact-short-text.json"; sourceTree = "<group>"; };
 		FAD3201324B647580044C83E /* fact-long-text.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "fact-long-text.json"; sourceTree = "<group>"; };
 		FAD3201524B64A6C0044C83E /* FactItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactItemViewModel.swift; sourceTree = "<group>"; };
@@ -292,6 +296,7 @@
 		FA1CF5BF24B0EBBD00409CB0 /* NorrisFactsTests */ = {
 			isa = PBXGroup;
 			children = (
+				FA6DB3FF24C38C66005D0C5E /* Mocks */,
 				FA1CF64024B5144A00409CB0 /* Helpers */,
 				FA1CF61D24B3852700409CB0 /* Core */,
 				FA1CF61624B3802000409CB0 /* Scenes */,
@@ -547,6 +552,15 @@
 				FAD3201324B647580044C83E /* fact-long-text.json */,
 			);
 			path = stubs;
+			sourceTree = "<group>";
+		};
+		FA6DB3FF24C38C66005D0C5E /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				FA6DB40024C38C79005D0C5E /* HttpServiceMock.swift */,
+				FA6DB40224C38CBA005D0C5E /* NorrisFactServiceMock.swift */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 		FAD3201724B79D5F0044C83E /* Responses */ = {
@@ -1043,10 +1057,12 @@
 				FAD3203E24BA3DC00044C83E /* FactsListErrorViewModelTests.swift in Sources */,
 				FA1CF61924B3804700409CB0 /* FactsListViewModelTests.swift in Sources */,
 				FAD3204A24BAD3210044C83E /* SearchFactViewModelTests.swift in Sources */,
+				FA6DB40124C38C79005D0C5E /* HttpServiceMock.swift in Sources */,
 				FAD3206B24BE55C30044C83E /* SearchFactViewControllerTests.swift in Sources */,
 				FA1CF62024B3853E00409CB0 /* FactCategoryTests.swift in Sources */,
 				FA1CF63524B4212700409CB0 /* NorrisFactsServiceTests.swift in Sources */,
 				FAD3201624B64A6C0044C83E /* FactItemViewModel.swift in Sources */,
+				FA6DB40324C38CBA005D0C5E /* NorrisFactServiceMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NorrisFacts/Core/Data/Networking/NorrisFactsAPI.swift
+++ b/NorrisFacts/Core/Data/Networking/NorrisFactsAPI.swift
@@ -46,7 +46,7 @@ extension NorrisFactsAPI: TargetType {
         return ["Content-type": "application/json"]
     }
 
-    var sampleData: Data? {
+    var sampleData: HttpResponse? {
         
         guard LaunchArgument.check(.useMockHttpRequests) else {
             return nil
@@ -54,9 +54,11 @@ extension NorrisFactsAPI: TargetType {
         
         switch self {
         case .getCategories:
-            return stub("get-categories")
+            return HttpResponse(statusCode: 200,
+                                data: stub("get-categories"))
         case .search:
-            return stub("search-facts")
+            return HttpResponse(statusCode: 200,
+                                data: stub("search-facts"))
         }
 
     }

--- a/NorrisFacts/Core/Error/NorrisFactsError.swift
+++ b/NorrisFacts/Core/Error/NorrisFactsError.swift
@@ -66,3 +66,9 @@ enum NetworkError: NorrisFactsErrorType, LocalizedError {
         }
     }
 }
+
+extension NetworkError: Equatable {
+    static func == (lhs: NetworkError, rhs: NetworkError) -> Bool {
+        return lhs.code == rhs.code
+    }
+}

--- a/NorrisFacts/Core/Error/NorrisFactsError.swift
+++ b/NorrisFacts/Core/Error/NorrisFactsError.swift
@@ -47,13 +47,15 @@ enum NetworkError: NorrisFactsErrorType, LocalizedError {
     case jsonMapping(Error?)
     case connectionError
     case noInternetConnection
-
+    case statusCodeError(Int)
+    
     var code: Int {
         switch self {
         case .unknow: return 0
         case .jsonMapping: return 1
         case .connectionError: return 2
         case .noInternetConnection: return 3
+        case .statusCodeError: return 4
         }
     }
     
@@ -63,6 +65,7 @@ enum NetworkError: NorrisFactsErrorType, LocalizedError {
         case .jsonMapping(let err): return err?.localizedDescription ?? "Parser error"
         case .connectionError: return "Connection Error"
         case .noInternetConnection: return "No internet connection"
+        case .statusCodeError(let statusCode): return "Status code error \(statusCode)"
         }
     }
 }

--- a/NorrisFacts/Scenes/Facts/FactsList/Cells/FactTableViewCell.swift
+++ b/NorrisFacts/Scenes/Facts/FactsList/Cells/FactTableViewCell.swift
@@ -29,6 +29,7 @@ class FactTableViewCell: UITableViewCell {
     
     override func prepareForReuse() {
         disposeBag = DisposeBag()
+        super.prepareForReuse()
     }
     
     private func setupViews() {

--- a/NorrisFacts/Scenes/Facts/FactsList/FactsListViewController.swift
+++ b/NorrisFacts/Scenes/Facts/FactsList/FactsListViewController.swift
@@ -254,11 +254,13 @@ extension FactsListViewController {
         
         // show error view when empty list
         // show error toast when list is not empty
+        let showErrorView = errorViewModel.withLatestFrom(isFactListEmpty)
+        
         Observable
-            .combineLatest(isFactListEmpty, errorViewModel )
+            .combineLatest(showErrorView, errorViewModel)
             .observeOn(MainScheduler.instance)
-            .bind { [weak self] isFactListEmpty, errorViewModel in
-                if isFactListEmpty {
+            .bind { [weak self] showErrorView, errorViewModel in
+                if showErrorView {
                     self?.bindErrorViewModel(errorViewModel)
                 } else {
                     self?.showToast(text: errorViewModel.errorMessage)

--- a/NorrisFacts/Scenes/Facts/FactsList/FactsListViewModel.swift
+++ b/NorrisFacts/Scenes/Facts/FactsList/FactsListViewModel.swift
@@ -151,10 +151,10 @@ struct FactsListViewModel: FactsListViewModelType, FactsListViewModelInput, Fact
             .flatMapLatest {
                 factsService.searchFacts(searchTerm: $0)
                     .trackActivity(_isLoading)
+                    .materialize()
             }
         
         let searchFactsError = searchFacts
-            .materialize()
             .errors()
             .map { FactListError.loadFacts($0) }
         

--- a/NorrisFactsTests/Mocks/HttpServiceMock.swift
+++ b/NorrisFactsTests/Mocks/HttpServiceMock.swift
@@ -1,0 +1,26 @@
+//
+//  HttpServiceMock.swift
+//  NorrisFactsTests
+//
+//  Created by Antony Nelson Daudt Alkmim on 18/07/20.
+//  Copyright © 2020 Antony Nelson Daudt Alkmim. All rights reserved.
+//
+
+import Foundation
+@testable import NorrisFacts
+
+final class HttpServiceMock: HttpService<NorrisFactsAPI> {
+    
+    var responseResult: Result<HttpResponse, NorrisFactsError>?
+    
+    override func request(_ endpoint: NorrisFactsAPI, completion: @escaping RequestCompletionHandler) -> URLSessionDataTask? {
+        completion(responseResult ?? .failure(.unknow(nil)))
+        return nil
+    }
+    
+    func mockRequest(statusCode: Int = 200, _ data: Data?) {
+        let httpResponse = HttpResponse(statusCode: statusCode, data: data)
+        self.responseResult = .success(httpResponse)
+    }
+    
+}

--- a/NorrisFactsTests/Mocks/NorrisFactServiceMock.swift
+++ b/NorrisFactsTests/Mocks/NorrisFactServiceMock.swift
@@ -1,0 +1,40 @@
+//
+//  NorrisFactServiceMock.swift
+//  NorrisFactsTests
+//
+//  Created by Antony Nelson Daudt Alkmim on 18/07/20.
+//  Copyright © 2020 Antony Nelson Daudt Alkmim. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+@testable import NorrisFacts
+
+class NorrisFactsServiceMocked: NorrisFactsServiceType {
+    
+    var syncFactsCategoriesResult: Observable<Void> = .just(())
+    var getFactsResult: [String: Observable<[NorrisFact]>] = ["": .just([])]
+    var searchFactsResult: Observable<[NorrisFact]> = .just([])
+    var getCategoriesResult: Observable<[FactCategory]> = .just([])
+    var getPastSearchTermsResult: Observable<[String]> = .just([])
+    
+    func syncFactsCategories() -> Observable<Void> {
+        syncFactsCategoriesResult
+    }
+    
+    func getFacts(searchTerm: String) -> Observable<[NorrisFact]> {
+        getFactsResult[searchTerm] ?? .just([])
+    }
+    
+    func searchFacts(searchTerm: String) -> Observable<[NorrisFact]> {
+        searchFactsResult
+    }
+    
+    func getFactCategories() -> Observable<[FactCategory]> {
+        getCategoriesResult
+    }
+    
+    func getPastSearchTerms() -> Observable<[String]> {
+        getPastSearchTermsResult
+    }
+}

--- a/NorrisFactsTests/Scenes/FactsList/FactsListViewModelTests.swift
+++ b/NorrisFactsTests/Scenes/FactsList/FactsListViewModelTests.swift
@@ -262,32 +262,3 @@ class FactsListViewModelTests: XCTestCase {
     }
     
 }
-
-class NorrisFactsServiceMocked: NorrisFactsServiceType {
-    
-    var syncFactsCategoriesResult: Observable<Void> = .just(())
-    var getFactsResult: [String: Observable<[NorrisFact]>] = ["": .just([])]
-    var searchFactsResult: Observable<[NorrisFact]> = .just([])
-    var getCategoriesResult: Observable<[FactCategory]> = .just([])
-    var getPastSearchTermsResult: Observable<[String]> = .just([])
-    
-    func syncFactsCategories() -> Observable<Void> {
-        syncFactsCategoriesResult
-    }
-    
-    func getFacts(searchTerm: String) -> Observable<[NorrisFact]> {
-        getFactsResult[searchTerm] ?? .just([])
-    }
-    
-    func searchFacts(searchTerm: String) -> Observable<[NorrisFact]> {
-        searchFactsResult
-    }
-    
-    func getFactCategories() -> Observable<[FactCategory]> {
-        getCategoriesResult
-    }
-    
-    func getPastSearchTerms() -> Observable<[String]> {
-        getPastSearchTermsResult
-    }
-}


### PR DESCRIPTION
# Description
Added auto-retry for API requests when responses http status code be between 400 and 600
- added method `errorWhenStatusCode(...)` for Observable streams
- added method `.retryWhen(statusCode: Range ....)` to auto retry for API requests errors


